### PR TITLE
add icon in navbar

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {track} from '@/utils/analytics';
+import {MagnifyingGlassIcon} from '@radix-ui/react-icons';
 import Icon from './Icon';
 import Tooltip from './Tooltip';
 import useRemoteTokens from '../store/remoteTokens';
 import {StorageProviderType} from '../../../types/api';
 import {RootState, Dispatch} from '../store';
-import useTokens from '../store/useTokens';
-import Button from './Button';
 
 const TabButton = ({name, label, first = false}) => {
     const {activeTab} = useSelector((state: RootState) => state.uiState);
@@ -46,6 +45,7 @@ const transformProviderName = (provider) => {
 
 const Navbar = () => {
     const {projectURL, storageType} = useSelector((state: RootState) => state.uiState);
+    const {toggleFilterVisibility} = useDispatch<Dispatch>().uiState;
     const {pullTokens} = useRemoteTokens();
 
     return (
@@ -58,6 +58,11 @@ const Navbar = () => {
                 <TabButton name="settings" label="Settings" />
             </div>
             <div className="flex flex-row items-center">
+                <Tooltip variant="right" label="Filter tokens">
+                    <button onClick={toggleFilterVisibility} type="button" className="button button-ghost">
+                        <MagnifyingGlassIcon />
+                    </button>
+                </Tooltip>
                 {storageType.provider !== StorageProviderType.LOCAL && (
                     <>
                         {projectURL && (

--- a/src/app/components/TokenFilter.tsx
+++ b/src/app/components/TokenFilter.tsx
@@ -18,8 +18,16 @@ const TokenFilter = () => {
         debounced(value);
     };
 
+    const searchInput: React.RefObject<HTMLInputElement> = React.useRef(null);
+
+    React.useEffect(() => {
+        setTimeout(() => {
+            searchInput.current.focus();
+        }, 50);
+    }, []);
+
     return (
-        <div className="flex flex-col flex-grow p-4">
+        <div className="flex flex-col flex-grow p-4 pb-0">
             <Input
                 full
                 label="Filter tokens"
@@ -28,6 +36,7 @@ const TokenFilter = () => {
                 onChange={(e) => handleChange(e.target.value)}
                 type="search"
                 name="filter"
+                inputRef={searchInput}
             />
         </div>
     );

--- a/src/app/components/Tokens.tsx
+++ b/src/app/components/Tokens.tsx
@@ -26,7 +26,7 @@ interface TokenListingType {
 
 const Tokens = ({isActive}) => {
     const {tokens, usedTokenSet, activeTokenSet} = useSelector((state: RootState) => state.tokenState);
-    const {showEditForm, tokenFilter} = useSelector((state: RootState) => state.uiState);
+    const {showEditForm, tokenFilter, tokenFilterVisible} = useSelector((state: RootState) => state.uiState);
 
     const resolvedTokens = React.useMemo(() => {
         return resolveTokenValues(computeMergedTokens(tokens, [...usedTokenSet, activeTokenSet]));
@@ -44,7 +44,7 @@ const Tokens = ({isActive}) => {
     return (
         <div>
             <TokenSetSelector />
-            <TokenFilter />
+            {tokenFilterVisible && <TokenFilter />}
             {memoizedTokens.map(([key, group]: [string, TokenListingType]) => {
                 return (
                     <div key={key}>

--- a/src/app/store/models/uiState.tsx
+++ b/src/app/store/models/uiState.tsx
@@ -48,6 +48,7 @@ interface UIState {
     editToken: EditToken | null;
     showEditForm: boolean;
     tokenFilter: string;
+    tokenFilterVisible: boolean;
 }
 
 export const uiState = createModel<RootModel>()({
@@ -74,6 +75,7 @@ export const uiState = createModel<RootModel>()({
         editToken: null,
         showEditForm: false,
         tokenFilter: '',
+        tokenFilterVisible: false,
     } as UIState,
     reducers: {
         setDisabled: (state, data: boolean) => {
@@ -173,6 +175,12 @@ export const uiState = createModel<RootModel>()({
             return {
                 ...state,
                 lastOpened: payload,
+            };
+        },
+        toggleFilterVisibility(state) {
+            return {
+                ...state,
+                tokenFilterVisible: !state.tokenFilterVisible,
             };
         },
         setTokenFilter(state, payload: string) {


### PR DESCRIPTION
I think having the filter field visible at all times might not be desired for **all** users. This PR adds an icon in the navbar that toggles the visibility of the filter field and focuses that after that.